### PR TITLE
Fix draft order note attributes JSON tag

### DIFF
--- a/draft_order.go
+++ b/draft_order.go
@@ -44,7 +44,7 @@ type DraftOrder struct {
 	ShippingAddress *Address         `json:"shipping_address,omitempty"`
 	BillingAddress  *Address         `json:"billing_address,omitempty"`
 	Note            string           `json:"note,omitempty"`
-	NoteAttributes  []NoteAttribute  `json:"note_attribute,omitempty"`
+	NoteAttributes  []NoteAttribute  `json:"note_attributes,omitempty"`
 	Email           string           `json:"email,omitempty"`
 	Currency        string           `json:"currency,omitempty"`
 	InvoiceSentAt   *time.Time       `json:"invoice_sent_at,omitempty"`


### PR DESCRIPTION
Before this commit, the JSON tag of the NoteAttributes field in the DraftOrder struct
was singular but should be plural.

See Shopify API documentation:
https://shopify.dev/docs/admin-api/rest/reference/orders/draftorder